### PR TITLE
Enables the Rails 8.1 framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ Bundler.require(*Rails.groups)
 module Invoicing
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 8.0
+    config.load_defaults 8.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/spec/system/client_sessions_spec.rb
+++ b/spec/system/client_sessions_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe "Client Sessions", type: :system do
 
         # Wait for the redirect to complete
         expect(page).to have_content("Client session was successfully destroyed")
-        expect(current_path).to eq(client_sessions_path)
+        expect(page).to have_current_path(client_sessions_path)
       end
     end
 
@@ -356,15 +356,15 @@ RSpec.describe "Client Sessions", type: :system do
       click_link "View"
 
       expect(page).to have_selector("h1", text: "Session Details")
-      expect(current_path).to eq(client_session_path(client_session))
+      expect(page).to have_current_path(client_session_path(client_session))
 
       click_link "Edit"
 
       expect(page).to have_selector("form[action='#{client_session_path(client_session)}']")
-      expect(current_path).to eq(edit_client_session_path(client_session))
+      expect(page).to have_current_path(edit_client_session_path(client_session))
 
       click_link "Back"
-      expect(current_path).to eq(client_sessions_path)
+      expect(page).to have_current_path(client_sessions_path)
     end
   end
 

--- a/spec/system/invoices_spec.rb
+++ b/spec/system/invoices_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe "Invoices", type: :system do
       click_link "#{invoice.id}"
 
       expect(page.find("div.invoice-info > table > tbody > tr:nth-child(1) > td")).to have_content(invoice.id.to_s)
-      expect(current_path).to eq(invoice_path(invoice))
+      expect(page).to have_current_path(invoice_path(invoice))
     end
   end
 end

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "Messages", type: :system do
       click_button "Update Message"
 
       expect(page).to have_content("prohibited this message from being saved")
-      expect(current_path).to eq(edit_message_path(message)) # Should render edit template
+      expect(page).to have_current_path(edit_message_path(message)) # Should render edit template
     end
   end
 


### PR DESCRIPTION
## Summary

The app has been running Rails 8.1 while `config/application.rb` still declared `config.load_defaults 8.0`, so none of the 8.1 defaults were active. This enables them.

## What 8.1 turns on

| Setting | New value |
| --- | --- |
| `yjit` | enabled outside dev/test |
| `action_controller.escape_json_responses` | `false` |
| `action_controller.action_on_path_relative_redirect` | `:raise` |
| `active_record.raise_on_missing_required_finder_order_columns` | `true` |
| `active_support.escape_js_separators_in_json` | `false` |
| `action_view.render_tracker` | `:ruby` |
| `action_view.remove_hidden_field_autocomplete` | `true` |

Confirmed active by reading them back off `Rails.application.config` in the test environment.

## Security-relevant flags reviewed

Two of these reduce escaping, so I checked the app's actual exposure rather than assuming:

- **`escape_json_responses = false`** — the only JSON endpoint is `clients/current_rate.json.jbuilder`, which renders `@client.id` (integer), `@client.current_rate.to_f` (float) and a Rails-generated URL. No user-controlled strings.
- **`escape_js_separators_in_json = false`** — only matters when JSON is embedded in markup as a JS literal. There are no `<script>` blocks, `raw` calls or `html_safe` calls in any view, so nothing interpolates JSON into HTML.

Both are therefore inert for this codebase. Brakeman reports no warnings.

## Bundled flaky-spec fix

Enabling 8.1 surfaced an intermittent failure in `client_sessions_spec.rb` "can navigate between pages". I checked whether this was a regression before treating it as one, and it is not: the same spec fails under the **existing 8.0 defaults** too, once in eight runs.

The cause is `expect(current_path).to eq(...)`, which reads the path with no waiting and so races the browser's navigation after `click_link`. Six occurrences are converted to `expect(page).to have_current_path(...)`, which retries. `clients_spec.rb` already used that matcher in three places, so this makes the suite consistent.

Measured effect on the affected spec:

| | Failures |
| --- | --- |
| Before, 8.0 defaults | 1 / 8 |
| Before, 8.1 defaults | 2 / 5 |
| After fix, 8.1 defaults | **0 / 10** |

## Verification

Two consecutive full runs: **439 examples, 0 failures, 1 known pending**. RuboCop clean, Brakeman clean.

## Note

`yjit` only applies outside dev and test, so this PR's green CI does not exercise it. Worth a glance at boot on first deploy — Ruby 4.0 also ships ZJIT, and only YJIT is being enabled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)