### PR TITLE
Upgrades money-rails to 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 # Money gem for handling money and currency conversions
-gem "money-rails", "~>2.0"
+gem "money-rails", "~> 3.0"
 # HTML to PDF conversion with Ferrum [https://github.com/rails/ferrum-pdf]
 gem "ferrum_pdf"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,11 +226,11 @@ GEM
     money (7.1.1)
       bigdecimal
       i18n (~> 1.9)
-    money-rails (2.0.0)
-      activesupport (>= 6.1)
+    money-rails (3.0.0)
+      activesupport (>= 7.0)
       monetize (~> 2.0)
       money (~> 7.0)
-      railties (>= 6.1)
+      railties (>= 7.0)
     msgpack (1.8.4)
     net-imap (0.6.6)
       date
@@ -486,7 +486,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
-  money-rails (~> 2.0)
+  money-rails (~> 3.0)
   numbers_and_words
   propshaft
   puma (>= 5.0)


### PR DESCRIPTION
## Summary

Clears the one deprecation the application still emits, which becomes a hard failure in Rails 8.2:

```
DEPRECATION WARNING: MoneyRails::ActiveJob::MoneySerializer should implement
a public #klass method. This will raise an error in Rails 8.2.
```

Moves the constraint from `"~>2.0"` to `"~> 3.0"`.

## Why 3.0.0 fixes it

I compared the serializer source across both versions rather than trusting the changelog alone. 2.0.0 overrides `serialize?` but never defines `klass`, which is exactly what Rails 8.1 deprecates. 3.0.0 adds it:

```ruby
def klass
  Money
end
```

The 3.0.0 changelog records this as *"Fix deprecation warning on the ActiveJob serializer to support future Rails 8.2 (#729)"*.

## Upgrade risk

The only breaking change in 3.0.0 is dropping support for Rails < 7.0, which does not apply. Its remaining requirements were already satisfied:

| Requirement | Locked | |
| --- | --- | --- |
| `ruby >= 3.1` | 4.0.6 | ok |
| `railties >= 7.0` | 8.1.3.1 | ok |
| `money ~> 7.0` | 7.1.1 | ok |
| `monetize ~> 2.0` | 2.0.0 | ok |

So `Gemfile.lock` moves `money-rails` alone. `money` and `monetize` do not change, and no other gem versions shift.

## Verification

- The `MoneySerializer` warning no longer appears, and no other deprecations are emitted
- Full suite: **439 examples, 0 failures, 1 known pending**
- RuboCop clean, Brakeman clean

Note the warning surfaces through `require "rspec/rails"` rather than at plain application boot, so `bundle exec rspec` is the way to reproduce it, not `rails runner`.

## Ordering note

This branch is based on `main`, so it does not include the flaky-spec fix from #88. `client_sessions_spec.rb:352` "can navigate between pages" therefore remains intermittent here, failing roughly one run in six, from a pre-existing `expect(current_path)` race unrelated to money-rails. If CI shows that single failure, it is that flake. Merging #88 first and rebasing this branch removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)